### PR TITLE
allow only one NavBar per view

### DIFF
--- a/Codist/NaviBar/NaviBarFactory.cs
+++ b/Codist/NaviBar/NaviBarFactory.cs
@@ -90,6 +90,10 @@ namespace Codist.NaviBar
 				_View.VisualElement.Loaded -= AddNaviBar;
 
 				var view = sender as FrameworkElement;
+				if (_View.Properties.ContainsProperty(nameof(NaviBar)))
+				{
+					return;
+				}
 				var naviBar = view
 					?.GetParent<Border>(b => b.Name == "PART_ContentPanel")
 					?.GetFirstVisualChild<Border>(b => b.Name == "DropDownBarMargin");


### PR DESCRIPTION
`NaviBar` constructor throws `ArgumentException` at `textView.Properties.AddProperty(nameof(NaviBar), this);` when a `NaviBar` already exists in a view. Add check to prevent creation of second `NaviBar` in a view.