### PR TITLE
Worked around null reference.

### DIFF
--- a/Codist/Commands/AutoSurroundSelectionCommand.cs
+++ b/Codist/Commands/AutoSurroundSelectionCommand.cs
@@ -49,7 +49,7 @@ namespace Codist.Commands
 
 		static bool IsChineseEnvironment() {
 			return System.Globalization.CultureInfo.CurrentCulture.LCID.CeqAny(2052, 3076, 5124, 1028, 4100)
-				|| R.Culture.LCID.CeqAny(2052, 3076, 5124, 1028, 4100);
+				|| (R.Culture != null && R.Culture.LCID.CeqAny(2052, 3076, 5124, 1028, 4100));
 		}
 
 		protected abstract string GetEndTextForTypedChar(char ch);


### PR DESCRIPTION
Noticed this crash when using your plugin. Maybe there's a better fix, but this gets the plugin working again.